### PR TITLE
Upgrade pysignalr to version 1.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 dependencies = [
     "aiohttp~=3.11",
     "jsonpickle~=4.0.0",
-    "pysignalr~=1.1.0",
+    "pysignalr~=1.3.0",
 ]
 description = "Swing2Sleep Smarla API"
 license = "Apache-2.0"


### PR DESCRIPTION
pysmarlaapi is now included in Homeassistant Docker images by default. Adding it caused the websockets library to be downgraded from version 15 to version 13, which is problematic for other things.

This is caused by pysmarlaapi requiring pysignalr version 1.1.0 which then has a hard dependency on websockets version 13. The latest version of pysignalr is using websockets 15, so upgrading pysmarlaapi to use that instead fixes the problem.

Since this project does not have any unit tests and I don't have the hardware to test this with (I don't actually even know what that hardware might be) this PR is entirely untested.