### PR TITLE
Loosen requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,9 +14,9 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "aiohttp~=3.11",
-    "jsonpickle~=4.0.0",
-    "pysignalr~=1.1.0",
+    "aiohttp>=3.11",
+    "jsonpickle>=4.0.0",
+    "pysignalr>=1.1.0",
 ]
 description = "Swing2Sleep Smarla API"
 license = "Apache-2.0"


### PR DESCRIPTION
Pinning dependencies this closely in a library is problematic for downstream consumers like Home Assistant. It will cause unnecessary dependency conflicts even if in almost all cases the libraries are fully compatible. It's much better, and often recommended, to only specify lower bounds for requirements.

This also addresses the websockets issue described in #1.